### PR TITLE
fix: using from_nonextended vs noforce which throws an exception

### DIFF
--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -22,7 +22,7 @@ fn xprv_to_vec(xprv: XPrv) -> Vec<Uint8Array> {
  * coerce given nonextended key and chain_code to valid ed25519 values or panic
  */
 #[wasm_bindgen]
-pub fn from_nonextended_noforce(
+pub fn from_nonextended(
   key: Uint8Array,
   chain_code: Uint8Array,
 ) -> Vec<Uint8Array> {
@@ -31,7 +31,7 @@ pub fn from_nonextended_noforce(
   key.copy_to(&mut sk_bytes);
   chain_code.copy_to(&mut cc_bytes);
 
-  let xprv = XPrv::from_nonextended_noforce(&sk_bytes, &cc_bytes).unwrap();
+  let xprv = XPrv::from_nonextended_force(&sk_bytes, &cc_bytes).unwrap();
   return xprv_to_vec(xprv);
 }
 

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -31,7 +31,7 @@ pub fn from_nonextended(
   key.copy_to(&mut sk_bytes);
   chain_code.copy_to(&mut cc_bytes);
 
-  let xprv = XPrv::from_nonextended_force(&sk_bytes, &cc_bytes).unwrap();
+  let xprv = XPrv::from_nonextended_force(&sk_bytes, &cc_bytes);
   return xprv_to_vec(xprv);
 }
 

--- a/wrapper/ed25519_bip32.udl
+++ b/wrapper/ed25519_bip32.udl
@@ -1,5 +1,5 @@
 namespace ed25519_bip32_wrapper {
-  record<string, bytes> from_nonextended_noforce(bytes sk, bytes chain_code);
+  record<string, bytes> from_nonextended(bytes sk, bytes chain_code);
 
   record<string, bytes> derive_bytes(bytes sk, bytes chain_code, u32 index);
 };

--- a/wrapper/src/wrapper.rs
+++ b/wrapper/src/wrapper.rs
@@ -17,7 +17,7 @@ pub fn from_nonextended(
 ) -> HashMap<String, Vec<u8>> {
   let sk_bytes: [u8; 32] = sk.as_slice().try_into().unwrap();
   let cc_bytes: [u8; 32] = chain_code.as_slice().try_into().unwrap();
-  let xprv = XPrv::from_nonextended_force(&sk_bytes, &cc_bytes).unwrap();
+  let xprv = XPrv::from_nonextended_force(&sk_bytes, &cc_bytes);
 
   return xprv_to_hashmap(xprv);
 }

--- a/wrapper/src/wrapper.rs
+++ b/wrapper/src/wrapper.rs
@@ -11,13 +11,13 @@ fn xprv_to_hashmap(xprv: XPrv) -> HashMap<String, Vec<u8>> {
   ]);
 }
 
-pub fn from_nonextended_noforce(
+pub fn from_nonextended(
   sk: Vec<u8>,
   chain_code: Vec<u8>,
 ) -> HashMap<String, Vec<u8>> {
   let sk_bytes: [u8; 32] = sk.as_slice().try_into().unwrap();
   let cc_bytes: [u8; 32] = chain_code.as_slice().try_into().unwrap();
-  let xprv = XPrv::from_nonextended_noforce(&sk_bytes, &cc_bytes).unwrap();
+  let xprv = XPrv::from_nonextended_force(&sk_bytes, &cc_bytes).unwrap();
 
   return xprv_to_hashmap(xprv);
 }


### PR DESCRIPTION
Adding the new function from_nonextended to the udl file, uniffy-rs wrapper and wasm.